### PR TITLE
Allow receipt of unsuccessful HTTP responses

### DIFF
--- a/dormouse-client/README.md
+++ b/dormouse-client/README.md
@@ -110,7 +110,7 @@ data PostmanEchoResponse = PostmanEchoResponse
 Once the request has been built, you can send it and expect a response of a particular type in any `MonadDormouseClient m`.
 
 ```haskell
-sendPostmanEchoGetReq :: MonadDormouseClient m => m PostmanEchoResponse
+sendPostmanEchoGetReq :: (MonadDormouseClient m, MonadThrow m) => m PostmanEchoResponse
 sendPostmanEchoGetReq = do
   (resp :: HttpResponse PostmanEchoResponse) <- expect postmanEchoGetReq'
   return $ responseBody resp

--- a/examples/src/RequestBuilding.hs
+++ b/examples/src/RequestBuilding.hs
@@ -3,6 +3,7 @@
 
 module RequestBuilding where
 
+import Control.Exception.Safe (MonadThrow)
 import Dormouse.Client
 import Dormouse.Url.QQ
 import Dormouse.Url.Builder
@@ -37,7 +38,7 @@ postmanEchoPostUrl = [https|https://postman-echo.com/post|]
 postmanEchoPostReq :: HttpRequest (Url "https") "POST" Empty EmptyPayload JsonPayload
 postmanEchoPostReq = accept json $ post postmanEchoPostUrl
 
-sendPostmanEchoGetReq :: MonadDormouseClient m => m ()
+sendPostmanEchoGetReq :: (MonadDormouseClient m, MonadThrow m) => m ()
 sendPostmanEchoGetReq = do
   (_ :: HttpResponse ()) <- expect postmanEchoGetReq'
   return()


### PR DESCRIPTION
At present, it's impossible to receive the body of an unsuccessful (non 2xx) HTTP response because `sendHttp` always throws.  This PR moves that behaviour as follows:

 - The success (2xx) checking has been moved to `expect`/`expectAs` in `Dormouse.Client`.
 - `expect`/`expectAs` now additionally have a `MonadThrow` constraint.
 - New `fetch`/`fetchAs` APIs have been exposes in `Dormouse.Client` which do not filter for 2xx responses and allow arbitrary response transformation.

Not addressed at this time:

- Ability to handle different content types for successful/unsuccessful content.

