### PR TITLE
Generalise builder methods so they accept "AnyUrl" as a parameter

### DIFF
--- a/dormouse-client/dormouse-client.cabal
+++ b/dormouse-client/dormouse-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           dormouse-client
-version:        0.3.0.0
+version:        0.4.0.0
 synopsis:       Simple, type-safe and testable HTTP client
 description:    An HTTP client designed to be productive, easy to use, easy to test, flexible and safe!
                 .
@@ -69,7 +69,7 @@ library
     , bytestring >=0.10.8 && <0.12.0
     , case-insensitive >=1.2.1.0 && <2.0.0
     , containers >=0.6.2.1 && <0.7
-    , dormouse-uri ==0.3.*
+    , dormouse-uri >=0.3 && <0.5
     , http-api-data >=0.4.1.1 && <0.6
     , http-client >=0.6.4.1 && <0.8.0
     , http-client-tls >=0.3.5.3 && <0.4

--- a/dormouse-client/package.yaml
+++ b/dormouse-client/package.yaml
@@ -1,5 +1,5 @@
 name:                dormouse-client
-version:             0.3.0.0
+version:             0.4.0.0
 github:              "theinnerlight/dormouse"
 license:             BSD3
 author:              Phil Curzon
@@ -64,7 +64,7 @@ library:
     - Dormouse.Client.Status
     - Dormouse.Client.Test.Class
   dependencies:
-    - dormouse-uri >= 0.3 && < 0.4
+    - dormouse-uri >= 0.3 && < 0.5
   ghc-options:
     - -Wall
   

--- a/dormouse-uri/dormouse-uri.cabal
+++ b/dormouse-uri/dormouse-uri.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           dormouse-uri
-version:        0.3.1.0
+version:        0.4.0.0
 synopsis:       Library for type-safe representations of Uri/Urls
 description:    Dormouse-Uri provides type safe handling of `Uri`s and `Url`s.
                 .

--- a/dormouse-uri/package.yaml
+++ b/dormouse-uri/package.yaml
@@ -1,5 +1,5 @@
 name:                dormouse-uri
-version:             0.3.1.0
+version:             0.4.0.0
 github:              "theinnerlight/dormouse"
 license:             BSD3
 author:              Phil Curzon

--- a/dormouse-uri/src/Dormouse/Url.hs
+++ b/dormouse-uri/src/Dormouse/Url.hs
@@ -13,6 +13,7 @@ module Dormouse.Url
   , httpUrlAsBS
   , httpsUrlAsBS
   , urlAsBS
+  , isUrlAsBS
   , IsUrl(..)
   ) where
 
@@ -73,6 +74,9 @@ httpsUrlAsBS (HttpsUrl httpsUrl) = "https://" <> componentsAsBS httpsUrl
 urlAsBS :: AnyUrl -> SB.ByteString
 urlAsBS (AnyUrl (HttpUrl httpUrl)) = httpUrlAsBS (HttpUrl httpUrl)
 urlAsBS (AnyUrl (HttpsUrl httpUrl)) = httpsUrlAsBS (HttpsUrl httpUrl)
+
+isUrlAsBS :: IsUrl url => url -> SB.ByteString
+isUrlAsBS = urlAsBS . asAnyUrl
 
 componentsAsBS :: UrlComponents -> SB.ByteString
 componentsAsBS uc =

--- a/dormouse-uri/src/Dormouse/Url.hs
+++ b/dormouse-uri/src/Dormouse/Url.hs
@@ -14,6 +14,7 @@ module Dormouse.Url
   , httpsUrlAsBS
   , urlAsBS
   , isUrlAsBS
+  , toSchemeAndComponents
   , IsUrl(..)
   ) where
 
@@ -89,6 +90,8 @@ componentsAsBS uc =
       fragment = maybe "" (\f -> "#" <> urlEncode False (TE.encodeUtf8 (unFragment f))) (urlFragment uc)
   in uInfo <> host <> port <> path <> queryString <> fragment
 
-
-
-
+toSchemeAndComponents :: IsUrl url => url -> (UrlScheme, UrlComponents)
+toSchemeAndComponents url =
+  case asAnyUrl url of
+    AnyUrl (HttpUrl uc)  -> (HttpScheme, uc)
+    AnyUrl (HttpsUrl uc) -> (HttpsScheme, uc)

--- a/dormouse-uri/src/Dormouse/Url/Builder.hs
+++ b/dormouse-uri/src/Dormouse/Url/Builder.hs
@@ -15,6 +15,7 @@ module Dormouse.Url.Builder
 
 import Data.Foldable  
 import Data.Text (Text)
+import Dormouse.Url.Class (IsUrl(mapIsUrl))
 import Dormouse.Uri.Types
 import Dormouse.Url.Types
 
@@ -51,9 +52,11 @@ instance IsQueryVal String where toQueryVal = T.pack
 instance IsQueryVal T.Text where toQueryVal = id
 
 -- | Combine a Url with a new text path component
-(</>) :: Url scheme -> Text -> Url scheme
-(</>) (HttpUrl UrlComponents {urlPath = path, .. }) text = HttpUrl $ UrlComponents {urlPath = (Path {unPath = unPath path ++ [PathSegment text] }), ..}
-(</>) (HttpsUrl UrlComponents {urlPath = path, .. }) text = HttpsUrl $ UrlComponents {urlPath = (Path {unPath = unPath path ++ [PathSegment text] }), ..}
+(</>) :: IsUrl url => url -> Text -> url
+(</>) url text = mapIsUrl f url where
+  f :: forall scheme. Url scheme -> Url scheme
+  f (HttpUrl UrlComponents {urlPath = path, .. }) = HttpUrl $ UrlComponents {urlPath = (Path {unPath = unPath path ++ [PathSegment text] }), ..}
+  f (HttpsUrl UrlComponents {urlPath = path, .. }) = HttpsUrl $ UrlComponents {urlPath = (Path {unPath = unPath path ++ [PathSegment text] }), ..}
 
 -- | Convenient alias for '<>' which allows for combining query parameters
 (&) :: QueryBuilder -> QueryBuilder -> QueryBuilder
@@ -61,15 +64,17 @@ instance IsQueryVal T.Text where toQueryVal = id
 
 -- | Combine a Url with a some supplied query parameters
 (?) :: Url scheme -> QueryBuilder -> Url scheme
-(?) uri b = 
-  case uri of 
-    HttpUrl  UrlComponents { .. } -> HttpUrl $ UrlComponents { urlQuery = Just $ foldl' folder "" $ unQueryBuilder b  , .. }
-    HttpsUrl UrlComponents { .. } -> HttpsUrl $ UrlComponents { urlQuery = Just $ foldl' folder "" $ unQueryBuilder b  , .. }
-  where 
-    folder "" (QueryFlag val)       = Query $ val
-    folder "" (QueryParam key val)  = Query $ key <> "=" <> val
-    folder acc (QueryFlag val)      = Query $ unQuery acc <> "&" <> val
-    folder acc (QueryParam key val) = Query $ unQuery acc <> "&" <> key <> "=" <> val
+(?) uri b = mapIsUrl f uri where
+  f :: forall scheme. Url scheme -> Url scheme
+  f uri' = 
+    case uri' of
+      (HttpUrl  UrlComponents { .. }) -> HttpUrl $ UrlComponents { urlQuery = Just $ foldl' folder "" $ unQueryBuilder b  , .. }
+      (HttpsUrl UrlComponents { .. }) -> HttpsUrl $ UrlComponents { urlQuery = Just $ foldl' folder "" $ unQueryBuilder b  , .. }
+    where
+      folder "" (QueryFlag val)       = Query $ val
+      folder "" (QueryParam key val)  = Query $ key <> "=" <> val
+      folder acc (QueryFlag val)      = Query $ unQuery acc <> "&" <> val
+      folder acc (QueryParam key val) = Query $ unQuery acc <> "&" <> key <> "=" <> val
 
 infixl 8 ?
 

--- a/dormouse-uri/src/Dormouse/Url/Class.hs
+++ b/dormouse-uri/src/Dormouse/Url/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Dormouse.Url.Class 
   ( IsUrl(..)
@@ -8,9 +9,13 @@ import Dormouse.Url.Types
 
 class (Eq url, Show url) => IsUrl url where
   asAnyUrl :: url -> AnyUrl
+  mapIsUrl :: (forall scheme. Url scheme -> Url scheme) -> url -> url
 
 instance IsUrl (Url scheme) where
   asAnyUrl = AnyUrl
+  mapIsUrl = id
 
 instance IsUrl AnyUrl where
   asAnyUrl (AnyUrl u) = asAnyUrl u
+  mapIsUrl f (AnyUrl u) = AnyUrl $ mapIsUrl f u
+


### PR DESCRIPTION
Using `</>` to build an `AnyUrl` was annoying because unlike many of the functions in `Dormouse.Client` which are generalised over `IsUrl`, `</>` and `?` where not.

Doing so has required adding an additional method to the `IsUrl` class called `mapIsUrl`, so this according to the PVP spec requires a major version bump, hence the move to 0.4.0.0, although I do doubt any users are actually defining their own `IsUrl` instances.

I've also added a generalised printing method `isUrlAsBS` which works on instances of the `IsUrl` class also, and a simple utility function to split out the scheme and components into a tuple.

p.s. This seems like a really well designed library. I hopped around a few URL libraries before finding this one, I found `modern-uri` whilst extensive was also too general without type constraints (resulting in various runtime checks at call sites) whereas with `req` like you said the ports being a separate type instead of part of the URL is weird and it didn't really have a inbuilt "print" method that included the port, and also the data type was quite opaque. Finally I stumbled into this and it for the moment (after a day of usage) fits the bill perfectly, so thanks for taking the time to write this.